### PR TITLE
Fix example for running lando docker image

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -26,6 +26,6 @@ docker run --rm \
 		-v ${PWD}:/code \
 		-v ${HOME}/.cargo/registry:/root/.cargo/registry \
 		-v ${HOME}/.cargo/git:/root/.cargo/git \
-		-e CARGO_FLAGS="--features python3-sys" \
+		-e CARGO_FLAGS="--features lando/python3-sys" \
 		softprops/lambda-rust:{tag}
 ```


### PR DESCRIPTION
The example is proper on the root README, but is wrong on Docker hub and the README in the builder folder. Should probably be fixed on the Docker hub docs too. Can be very confusing for newcomers.