### PR TITLE
re-export http crate and improve rustdocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ addons:
 
 install: |
   rustup toolchain install nightly
-  if [[ "$TRAVIS_RUST_VERSION" == stable ]] && [[ $(cargo tarpaulin  +nightly --version) != *0.6.2 ]]; then
-    `RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install  +nightly --force --version 0.6.2  cargo-tarpaulin`
+  if [[ "$TRAVIS_RUST_VERSION" == stable ]] && [[ $(cargo +nightly tarpaulin --version) != *0.6.2 ]]; then
+    `RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo +nightly install --force --version 0.6.2  cargo-tarpaulin`
   fi
 
 after_success:
@@ -41,7 +41,7 @@ after_success:
     [ $TRAVIS_RUST_VERSION = stable ] &&
     [ $TRAVIS_BRANCH = master ] &&
     [ $TRAVIS_PULL_REQUEST = false ] &&
-    cargo  +nightly tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID || true'
+    cargo +nightly tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID || true'
   - >-
     [ $TRAVIS_RUST_VERSION = stable ] && [ $TRAVIS_BRANCH = master ] && [
     $TRAVIS_PULL_REQUEST = false ] && cargo doc --no-deps && echo "<meta

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ addons:
       - libssl-dev
 
 install: |
-  if [[ "$TRAVIS_RUST_VERSION" == stable ]] && [[ $(cargo tarpaulin --version) != *0.6.2 ]]; then
-    `RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install  --force --version 0.6.2  cargo-tarpaulin`
+  rustup toolchain install nightly
+  if [[ "$TRAVIS_RUST_VERSION" == stable ]] && [[ $(cargo tarpaulin  +nightly --version) != *0.6.2 ]]; then
+    `RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install  +nightly --force --version 0.6.2  cargo-tarpaulin`
   fi
 
 after_success:
@@ -40,7 +41,7 @@ after_success:
     [ $TRAVIS_RUST_VERSION = stable ] &&
     [ $TRAVIS_BRANCH = master ] &&
     [ $TRAVIS_PULL_REQUEST = false ] &&
-    cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID || true'
+    cargo  +nightly tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID || true'
   - >-
     [ $TRAVIS_RUST_VERSION = stable ] && [ $TRAVIS_BRANCH = master ] && [
     $TRAVIS_PULL_REQUEST = false ] && cargo doc --no-deps && echo "<meta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,50 @@
+# 0.1.2
+
+* ease dependency declartions by re-exporting `http` crate
+
+before
+
+in your `Cargo.toml` file
+
+```toml
+[dependencies]
+lando = "0.1"
+http = "0.1" # need to depend on http crate explicitly
+...
+```
+
+in your `src/lib.rs`
+
+```rust
+#[macro_use]
+extern crate lando;
+// need to extern http crate explicitly
+extern crate http;
+...
+
+use http::{Method, StatusCode};
+```
+
+after
+
+in your `Cargo.toml`
+
+```toml
+[dependencies]
+lando = "0.1" # no longer need to add a dependency on http explicitly
+...
+```
+
+in your `src/lib.rs`
+
+```rust
+#[macro_use]
+extern crate lando;
+...
+// consume http re-export from lando crate
+use lando::http::{Method, StatusCode};
+```
+
 # 0.1.1
 
 * bug fix - support for reading host from "host" (lowercase) in addition to "Host"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@
 //! extern crate lando;
 //! ```
 //!
-//! And write your function using the [gateway!](macro.gateway.html) macro
+//! And write your function using the [gateway!](macro.gateway.html) macro. See
+//! It's documentation for more examples.
 //!
 //! ```rust
 //! # #[macro_use] extern crate cpython;
@@ -89,7 +90,8 @@ extern crate crowbar;
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;
-extern crate http as rust_http;
+// re-export for convenience
+pub extern crate http;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -107,20 +109,20 @@ pub use cpython::{PyObject, PyResult};
 pub use crowbar::LambdaContext;
 
 mod body;
-mod http;
+mod ext;
 pub mod request;
 mod response;
 
 pub use body::Body;
-pub use http::{PayloadError, RequestExt};
+pub use ext::{PayloadError, RequestExt};
 pub use request::GatewayRequest;
 
 /// A re-exported version of `http::Request` with a type
 /// parameter for body fixed to type [lando::Body](enum.Body.html)
-pub type Request = rust_http::Request<Body>;
+pub type Request = http::Request<Body>;
 
 /// A re-exported version of the `http::Response` type
-pub use rust_http::Response;
+pub use http::Response;
 
 /// Result type for gateway functions
 pub type Result = StdResult<Response<Body>, Box<StdError>>;
@@ -256,6 +258,7 @@ where
 ///     }
 /// };
 /// # }
+///
 /// ```
 #[macro_export]
 macro_rules! gateway {
@@ -294,7 +297,7 @@ macro_rules! gateway {
                             initliblambda,
                             PyInit_liblambda)
                   @handlers ($($handler => $target),*) }
-    };
+ };
     ($($handler:expr => $target:expr,)*) => {
         gateway! { $($handler => $target),* }
     };

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-//! Request types
+//! API Gateway request types. Typically these are exposed via the `request_context` method provided by [lando::RequestExt](trait.RequestExt.html)
 
 // Std
 use std::collections::HashMap;


### PR DESCRIPTION
fixes https://github.com/softprops/lando/issues/20. also touches up rustdocs a bit.

notable change is that there was already a private `http` module which represented extensions for the http crate. this is now called `ext` to avoid confusion with the re-exported crate identifier