### PR TITLE
(experimental) byo cratename

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_urlencoded = "0.5"
+mashup = "0.1"
 
 [features]
 default = ["cpython/python3-sys"]

--- a/README.md
+++ b/README.md
@@ -4,35 +4,30 @@
 <img src="https://raw.githubusercontent.com/softprops/lando/master/logo.png" width="300" />
 </p>
 
-> [aws lambda](https://aws.amazon.com/lambda/) [api gateway](https://aws.amazon.com/api-gateway/) interfaces for [Rustlang](https://www.rust-lang.org) applications
+> [AWS lambda](https://aws.amazon.com/lambda/) [API Gateway](https://aws.amazon.com/api-gateway/) interfaces for [Rustlang](https://www.rust-lang.org) http applications.
 
 ```rust
 #[macro_use] extern crate cpython;
 #[macro_use] extern crate lando;
 
 gateway!(|_, _| {
-  Ok(lando::Response::new("Hello, what have we here?"))
+  Ok(lando::Response::new("👋 Hello, what have we here?"))
 });
 ```
 
+
 ## 🤔 about
 
- 🚧 👷🏿‍♀️ 👷🏽 👷‍♀️ 👷 🚧 this project is currently active under construction. expect changes.
+Lando is a crate for **serverless** Rustlang HTTP applications.
 
-Lando is a crate for **serverless** rustlang HTTP applications.
+> The rustlang ecosystem has a number of really great [HTTP server crates](https://crates.io/categories/web-programming::http-server).
+A common property they all have is that they bundle servers that listen on ports that expose your application over network connections. A server which is then your reponsiblity to managing hosting, scaling, monitoring and operations for _in addition to_ your application code.
 
-> The rustlang ecosystem has a number of really great [HTTP server crates](https://crates.io/categories/web-programming::http-server), you may want to evaluate them as well.
-A common theme they share is in providing interfaces for authoring applications,
-in addition to interfaces for configuring servers that listen on ports that expose your application over network connections.
-A server which is then your reponsiblity to figure out how to host, scale,
-monitor and manage operations and uptime for.
+Lando is different. Lando's focus is solely on writing applications. It shifts the responsibility of hosting servers that listen on ports that exposes your application over network connections to AWS. This removes the [undifferentiated heavy lifting](https://www.cio.co.nz/article/466635/amazon_cto_stop_spending_money_undifferentiated_heavy_lifting_/) that comes along with managing servers yourself. Put more directly AWS lambda let's you run code without thinking about servers.
 
-Lando is different. Lando's focus is solely on writing applications. AWS will manage servers for you, freeing you from the business and toil of the [undifferentiated heavy lifting](https://www.cio.co.nz/article/466635/amazon_cto_stop_spending_money_undifferentiated_heavy_lifting_/) that comes along with managing servers yourself.
+Lando is designed to work with, not against, the interfaces of strong existing ecosystems, both within Rust as well as the strong serverless ecosystems that exist outside Rust.
 
-Lando is designed to work _with_ the interfaces of strong existing ecosystems, both within Rust as well as the strong serverless ecosystems that extend beyond Rust ( make some friends! ).
-
-Lando's embraces the Rust community standard [http](https://crates.io/crates/http) crate as it's interface for api gateway. The http crate was extracted from the work of a number of successful projects and was designed as a framework-agnostistic and extensible http library. Lando extends
-the existing work of the [crowbar](https://crates.io/crates/crowbar) crate which
+Lando's embraces the Rust community standard [http](https://crates.io/crates/http) crate as it's interface for API Gateway. Lando extends the existing work of the [crowbar](https://crates.io/crates/crowbar) crate which
 provides needed lower level machinery for easily embeding a Rust application with one of lamdba's
 [lowest overhead runtimes](https://theburningmonk.com/2017/06/aws-lambda-compare-coldstart-time-with-different-languages-memory-and-code-sizes/),
 python 3.6. Lando specifically targets API Gateway triggered lambdas. Checkout crowbar for other types of [lambda triggers](https://docs.aws.amazon.com/lambda/latest/dg/invoking-lambda-function.html).
@@ -41,17 +36,21 @@ A *large* and *mature* ecosystem of tooling for AWS lambda already exists and wo
 including workflow tools like [the serverless toolkit](https://serverless.com/framework/). Because these tools are likely to already exist within organizations, the barrier of introducing Rustlang into their arsenel will be much lower.
 Lando does not intend to replace these tools but instead to work well with them 👫🏾.
 
-> 💡 What makes Rust a good choice for Lambda applications?
+### 👍 What makes Rust a good choice for Lambda applications
+
 The AWS [cost model for lambda](https://aws.amazon.com/lambda/pricing/)
 is largely based on two factors: memory size and speed.
 The CPU provided to applications is proportional to memory size requested.
 Lambda has a pay per usage cost model billing favoring applications that are both fast and
 have low memory overheads.
+
 As a systems language, Rust is designed specifically for these kinds of needs. Rust
 has a very [tiny runtime](https://www.rust-lang.org/en-US/faq.html#does-rust-have-a-runtime),
 manages memory [very effciently](https://www.rust-lang.org/en-US/faq.html#is-rust-garbage-collected),
 and is [extremely fast](https://www.rust-lang.org/en-US/faq.html#how-fast-is-rust).
-. As a highly embeddable language, its interop story for runtimes like python's is 💖. Be mindful that lando assumes you're exposing these applications through AWS API gateway which has its own [generous pricing model](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html).
+.
+
+As a highly embeddable language, its interop story for runtimes like python's is 💖. Be mindful that lando assumes you're exposing these applications through AWS API gateway which has its own [generous pricing model](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html).
 
 ## 📦  install
 
@@ -67,7 +66,7 @@ lando = "0.1"
 cpython = "0.1"
 ```
 
-> 💡 You may be new to the `cdylib` and `crate-type` lib attributes. This informs rustc to [link](https://doc.rust-lang.org/reference/linkage.html) and produce a shared object ( `*.so` ) file allowing your rustlang application to be embedded within the AWS python 3.6 [lambda runtime](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html)
+> 💡 The `crate-type` property informs rustc to [link](https://doc.rust-lang.org/reference/linkage.html) and produce a shared object ( `*.so` ) file allowing your rustlang application to be embedded within the AWS python 3.6 [lambda runtime](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html)
 
 ## 👩‍🏭 create
 
@@ -153,11 +152,20 @@ the bottleneck of your application
 test gateway_conversion ... bench:       8,652 ns/iter (+/- 4,193)
 ```
 
-> 💡 Consideration for concurency should be noted. Performance is typically affected
-and related to scalability. Two models for scalabilty are veritical and horizontal.
-AWS Lamda is expressly horizontal scaled. The platform handles concurrency by spawning more
-instances of your function for you. This results in some economical advantages in
+### 💱 Concurrency
+
+Consideration for concurency should be noted when approaching performance with AWS lamda.
+
+AWS Lamda is expressly *horizontal scaled*. You scale not by spawning more threads in
+a running process ( scaling up ↕️ ) but by spawning more lambdas ( scaling out ↔️ ).
+
+A key benefit of AWS lambda is that the _platform_ handles concurrency by spawning more instances of your function *for you*. This results in some economical advantages in
 they way you only pay for what you use. Bear in mind you are billed at intervals of 100 milliseconds,
 so the usefulness optimizing for cost is lost once you're dipped below that point.
+
+# 🚧 planned changes
+
+* remove the need for explicit dependency on cpython
+* remove the need for awkward dependency on lambda lib name
 
 Doug Tangren (softprops) 2018

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,10 @@ extern crate failure;
 extern crate failure_derive;
 // re-export for convenience
 pub extern crate http;
+#[doc(hidden)]
+pub extern crate mashup;
+#[doc(hidden)]
+pub use mashup::*;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -291,11 +295,16 @@ macro_rules! gateway {
         // dynamic
         // see also https://www.ncameron.org/blog/untitledconcat_idents-and-macros-in-ident-position/
         // https://github.com/rust-lang/rust/issues/29599
-        gateway! { @module (liblambda,
-                            initliblambda,
-                            PyInit_liblambda)
+        mashup! {
+            m["modulename"] = lib env!("CARGO_PKG_NAME");
+            m["py2_init"] =  initlib env!("CARGO_PKG_NAME");
+            m["py3_init"] =  PyInit_lib env!("CARGO_PKG_NAME");
+        }
+        m! {
+          gateway! { @module ("modulename", "py2_init", "py3_init")
                   @handlers ($($handler => $target),*) }
- };
+        }
+    };
     ($($handler:expr => $target:expr,)*) => {
         gateway! { $($handler => $target),* }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,8 +297,8 @@ macro_rules! gateway {
         // https://github.com/rust-lang/rust/issues/29599
         mashup! {
             m["modulename"] = lib env!("CARGO_PKG_NAME");
-            m["py2_init"] =  initlib env!("CARGO_PKG_NAME");
-            m["py3_init"] =  PyInit_lib env!("CARGO_PKG_NAME");
+            m["py2_init"] = initlib env!("CARGO_PKG_NAME");
+            m["py3_init"] = PyInit_lib env!("CARGO_PKG_NAME");
         }
         m! {
           gateway! { @module ("modulename", "py2_init", "py3_init")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,18 +191,18 @@ where
 /// # }
 /// ```
 ///
-/// You can also the provide `gateway!` macro with a named function
+/// You can also the provide `gateway!` macro with a function reference
 ///
-/// The request argument is just a regular `http::Request` type
+/// The `request` argument is just a regular `http::Request` type,
 /// extendable with API gateway features, like accessing path and query string parameters, and
 /// more by importing [lando::RequestExt`](trait.RequestExt.html)
 ///
-/// The context argument is [same type](struct.LambdaContext.html) defined within the crowbar crate
+/// The context argument is [same type](struct.LambdaContext.html) defined within the crowbar crate.
 ///
 /// ```rust
 /// # #[macro_use] extern crate lando;
 /// # fn main() {
-/// use lando::{LambdaContext, Request, Response, Result, Body};
+/// use lando::{LambdaContext, Request, Response, Result};
 ///
 /// fn handler(request: Request, context: LambdaContext) -> Result {
 ///     println!("{:?}", request);
@@ -213,7 +213,7 @@ where
 /// # }
 /// ```
 ///
-/// # Multiple functions
+/// # Export multiple lambda functions in one library
 ///
 /// You can export multiple functions in the same module with a format similar to a `match` expression:
 ///
@@ -229,39 +229,6 @@ where
 /// # }
 /// ```
 ///
-/// # Changing the dynamic library name
-///
-/// Be default, lando assumes a library named "lambda", If you need to change the
-/// name of the resulting dynamic library that gets built,
-///  you first need to change the `[lib]` section in your Cargo.toml file
-///
-/// ```toml
-/// [lib]
-/// name = "solo"
-/// crate-type = ["cdylib"]
-/// ```
-///
-/// You then also need to change the names of the library identifiers, expected by
-/// the [cpython crate](https://dgrunwald.github.io/rust-cpython/doc/cpython/macro.py_module_initializer.html),
-/// by using the following `gateway!` format. This pattern may no longer needed
-/// the std library's [concat_idents!](https://doc.rust-lang.org/std/macro.concat_idents.html)
-/// macro is stablized.
-///
-/// ```rust
-/// # #[macro_use] extern crate lando;
-/// # fn main() {
-/// gateway! {
-///     crate (libsolo, initlibsolo, PyInit_libsolo) {
-///         "handler" => |request, context| {
-///            Ok(lando::Response::new(
-///               "hello from libsolo"
-///            ))
-///         }
-///     }
-/// };
-/// # }
-///
-/// ```
 #[macro_export]
 macro_rules! gateway {
     (@module ($module:ident, $py2:ident, $py3:ident)


### PR DESCRIPTION
fixes Mashup shim for stable concat_idents

this change solves for a gap in rust functionality that could potentially have been solved with `concat_indents!` but it seems that's [unlikely to stablize soon](https://github.com/rust-lang/rust/issues/29599) and this gap can now be filled by the mashup crate as of https://github.com/dtolnay/mashup/issues/11