### PR TITLE
better handling of binary data

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -18,7 +18,7 @@ use serde::ser::{Error as SerError, Serialize, Serializer};
 ///
 /// # Examples
 ///
-/// Body types are inverted with `From` implementations. Types like `String`, `str` whose type reflects
+/// Body types are inferred with `From` implementations. Types like `String`, `str` whose type reflects
 /// text produce `Body::Text` variants
 ///
 /// ```

--- a/src/body.rs
+++ b/src/body.rs
@@ -18,7 +18,11 @@ use serde::ser::{Error as SerError, Serialize, Serializer};
 ///
 /// # Examples
 ///
-/// Body types are inferred with `From` implementations. Types like `String`, `str` whose type reflects
+/// Body types are inferred with `From` implementations.
+///
+/// ## Text
+///
+/// Types like `String`, `str` whose type reflects
 /// text produce `Body::Text` variants
 ///
 /// ```
@@ -28,6 +32,8 @@ use serde::ser::{Error as SerError, Serialize, Serializer};
 /// })
 /// ```
 ///
+/// ## Binary
+///
 /// Types like `Vec<u8>` and `&[u8]` whose types reflect raw bytes produce `Body::Binary` variants
 ///
 /// ```
@@ -36,6 +42,10 @@ use serde::ser::{Error as SerError, Serialize, Serializer};
 ///   _ => false
 /// })
 /// ```
+///
+/// `Binary` responses bodies will automatcally get based64 encoded to meet API gateway's expectations.
+///
+/// ## Empty
 ///
 /// The unit type ( `()` ) whose type represents an empty value produces `Body::Empty` variants
 ///

--- a/src/body.rs
+++ b/src/body.rs
@@ -12,6 +12,41 @@ use serde::ser::{Error as SerError, Serialize, Serializer};
 /// Representation of http request and response bodies as supported
 /// by API Gateway.
 ///
+/// These come in three flavors `Empty` ( to body ), `Text` ( text data ), `Binary` ( binary data ).
+///
+/// Body types can be `Deref` and `AsRef`'d into `[u8]` types much like the `hyper` crate
+///
+/// # Examples
+///
+/// Body types are inverted with `From` implementations. Types like `String`, `str` whose type reflects
+/// text produce `Body::Text` variants
+///
+/// ```
+/// assert!(match lando::Body::from("text") {
+///   lando::Body::Text(_) => true,
+///   _ => false
+/// })
+/// ```
+///
+/// Types like `Vec<u8>` and `&[u8]` whose types reflect raw bytes produce `Body::Binary` variants
+///
+/// ```
+/// assert!(match lando::Body::from("text".as_bytes()) {
+///   lando::Body::Binary(_) => true,
+///   _ => false
+/// })
+/// ```
+///
+/// The unit type ( `()` ) whose type represents an empty value produces `Body::Empty` variants
+///
+/// ```
+/// assert!(match lando::Body::from(()) {
+///   lando::Body::Empty => true,
+///   _ => false
+/// })
+/// ```
+///
+///
 /// For more information about API Gateway's body types,
 /// refer to [this documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings.html).
 #[derive(Debug, PartialEq)]

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,4 +1,4 @@
-//! conversions to and from internal gateway types and http crate types
+//! Extension methods for `http::Request` types
 
 // Std
 use std::collections::HashMap;

--- a/src/response.rs
+++ b/src/response.rs
@@ -22,7 +22,7 @@ pub(crate) struct GatewayResponse {
     )]
     pub headers: HeaderMap<HeaderValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub body: Option<String>,
+    pub body: Option<Body>,
     #[serde(skip_serializing_if = "Not::not")]
     pub is_base64_encoded: bool,
 }
@@ -55,15 +55,17 @@ where
     T: Into<Body>,
 {
     fn from(value: HttpResponse<T>) -> Self {
-        let (parts, body) = value.into_parts();
+        let (parts, bod) = value.into_parts();
+        let (is_base64_encoded, body) = match bod.into() {
+            Body::Empty => (false, None),
+            b @ Body::Text(_) => (false, Some(b)),
+            b @ Body::Binary(_) => (true, Some(b)),
+        };
         GatewayResponse {
             status_code: parts.status.as_u16(),
-            body: match body.into() {
-                Body::Empty => None,
-                Body::Bytes(b) => Some(String::from_utf8_lossy(b.as_ref()).to_string()),
-            },
+            body,
             headers: parts.headers,
-            is_base64_encoded: Default::default(), // todo: infer from Content-{Encoding,Type} headers
+            is_base64_encoded,
         }
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -10,8 +10,6 @@ use serde::{ser::Error as SerError, ser::SerializeMap, Serializer};
 use body::Body;
 
 /// Representation of API Gateway response
-///
-/// # Examples
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct GatewayResponse {


### PR DESCRIPTION
aws gateway requests and responses can have no body or a body that represented as text or binary

https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings.html

this wasn't previously represented well in the type system. events have an is_base64_encoded flag but thats not exposed directly to clients so body type representation would be more appropriate.

This also fixes a previous problem where there was no way for handlers communicate this in responses.