### PR TITLE
hashmap to strmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ extern crate lando; // impl details are hidden
 
 Replaced many owned `String` types with `Cow`. Now deserializing and serializing request headers directly to `http::HeaderMap`
 
+* `RequestExt` methods now return `strmap::StrMap` type instead of `HashMap<String, String>`
+
 # 0.1.1
 
 * bug fix - support for reading host from "host" (lowercase) in addition to "Host"

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -9,7 +9,8 @@ use serde_json;
 use serde_urlencoded;
 
 // Ours
-use request::{RequestContext, StrMap};
+use request::RequestContext;
+use strmap::StrMap;
 
 /// API gateway pre-parsed http query string parameters
 pub(crate) struct QueryStringParameters(pub(crate) StrMap);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,10 @@
 //!
 //! Within your application's source, use lando's macros.
 //!
-//! ```rust,ignore
+//! ```
 //! #[macro_use]
 //! extern crate lando;
+//! # fn main() { }
 //! ```
 //!
 //! And write your function using the [gateway!](macro.gateway.html) macro. See
@@ -124,8 +125,8 @@ mod response;
 
 pub use body::Body;
 pub use ext::{PayloadError, RequestExt};
-// for benches only!
-pub use request::GatewayRequest;
+// GatewayRequest for benches only!
+pub use request::{GatewayRequest, StrMap};
 
 /// A re-exported version of `http::Request` with a type
 /// parameter for body fixed to type [lando::Body](enum.Body.html)
@@ -167,15 +168,24 @@ where
 /// `LambdaContext`) and are expected to return a result containing [lando::Response](struct.Response.html). The function signature should look
 /// like:
 ///
-/// ```rust,ignore
-/// fn handler(request: Request, context: LambdaContext) -> Result
+/// ```
+/// # extern crate lando;
+/// # use lando::{Request, LambdaContext, Result};
+/// fn handler(
+///   request: Request,
+///   context: LambdaContext
+/// ) -> Result {
+///   // impl...
+///   # Ok(lando::Response::new("docs".into()))
+/// }
 /// ```
 ///
 /// To use this macro, you need the following `macro_use` declaration
 ///
-/// ```rust,ignore
+/// ```
 /// #[macro_use]
 /// extern crate lando;
+/// # fn main() { }
 /// ```
 ///
 /// # Examples
@@ -205,9 +215,12 @@ where
 /// # fn main() {
 /// use lando::{LambdaContext, Request, Response, Result};
 ///
-/// fn handler(request: Request, context: LambdaContext) -> Result {
-///     println!("{:?}", request);
-///     Ok(Response::new("👍".into()))
+/// fn handler(
+///   request: Request,
+///   context: LambdaContext
+/// ) -> Result {
+///   println!("{:?}", request);
+///   Ok(Response::new("👍".into()))
 /// }
 ///
 /// gateway!(handler);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,11 +122,13 @@ mod body;
 mod ext;
 pub mod request;
 mod response;
+mod strmap;
 
 pub use body::Body;
 pub use ext::{PayloadError, RequestExt};
-// GatewayRequest for benches only!
-pub use request::{GatewayRequest, StrMap};
+//  for benches only!
+pub use request::GatewayRequest;
+pub use strmap::StrMap;
 
 /// A re-exported version of `http::Request` with a type
 /// parameter for body fixed to type [lando::Body](enum.Body.html)

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,10 +2,8 @@
 
 // Std
 use std::borrow::Cow;
-use std::collections::{hash_map::Keys, HashMap};
 use std::fmt;
 use std::mem;
-use std::sync::Arc;
 
 // Third Party
 use http::header::{HeaderValue, HOST};
@@ -15,6 +13,7 @@ use serde::{de::Error as DeError, de::MapAccess, de::Visitor, Deserialize, Deser
 
 use body::Body;
 use ext::{PathParameters, QueryStringParameters, StageVariables};
+use strmap::StrMap;
 
 /// Representation of an API Gateway proxy event data
 ///
@@ -39,83 +38,6 @@ pub struct GatewayRequest<'a> {
     #[serde(default)]
     pub(crate) is_base64_encoded: bool,
     pub(crate) request_context: RequestContext,
-}
-
-/// A read-only view into a map of string data
-#[derive(Default, Debug, PartialEq)]
-pub struct StrMap(pub(crate) Arc<HashMap<String, String>>);
-
-impl StrMap {
-    /// Return a named value where available
-    pub fn get(&self, key: &str) -> Option<&str> {
-        self.0.get(key).map(|value| value.as_ref())
-    }
-
-    /// Return true if the underlying map is empty
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Return an iterator over keys and values
-    pub fn iter(&self) -> StrMapIter {
-        StrMapIter(self, self.0.keys())
-    }
-}
-
-impl Clone for StrMap {
-    fn clone(&self) -> Self {
-        // only clone the inner data
-        StrMap(self.0.clone())
-    }
-}
-impl From<HashMap<String, String>> for StrMap {
-    fn from(inner: HashMap<String, String>) -> Self {
-        StrMap(Arc::new(inner))
-    }
-}
-
-/// A read only reference to `StrMap` key and value slice pairings
-pub struct StrMapIter<'a>(&'a StrMap, Keys<'a, String, String>);
-
-impl<'a> Iterator for StrMapIter<'a> {
-    type Item = (&'a str, &'a str);
-
-    #[inline]
-    fn next(&mut self) -> Option<(&'a str, &'a str)> {
-        self.1
-            .next()
-            .and_then(|k| self.0.get(k).map(|v| (k.as_str(), v)))
-    }
-}
-
-impl<'de> Deserialize<'de> for StrMap {
-    fn deserialize<D>(deserializer: D) -> Result<StrMap, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct StrMapVisitor;
-
-        impl<'de> Visitor<'de> for StrMapVisitor {
-            type Value = StrMap;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                write!(formatter, "a StrMap")
-            }
-
-            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where
-                A: MapAccess<'de>,
-            {
-                let mut inner = HashMap::new();
-                while let Some((key, value)) = map.next_entry()? {
-                    inner.insert(key, value);
-                }
-                Ok(StrMap(Arc::new(inner)))
-            }
-        }
-
-        deserializer.deserialize_map(StrMapVisitor)
-    }
 }
 
 /// API Gateway request context
@@ -255,31 +177,6 @@ mod tests {
     use super::*;
     use serde_json;
     use std::collections::HashMap;
-
-    #[test]
-    fn str_map_default_is_empty() {
-        assert!(StrMap::default().is_empty())
-    }
-
-    #[test]
-    fn str_map_get() {
-        let mut data = HashMap::new();
-        data.insert("foo".into(), "bar".into());
-        let strmap = StrMap(data.into());
-        assert_eq!(strmap.get("foo"), Some("bar"));
-        assert_eq!(strmap.get("bar"), None);
-    }
-
-    #[test]
-    fn str_map_iter() {
-        let mut data = HashMap::new();
-        data.insert("foo".into(), "bar".into());
-        data.insert("baz".into(), "boom".into());
-        let strmap = StrMap(data.into());
-        let mut values = strmap.iter().map(|(_, v)| v).collect::<Vec<_>>();
-        values.sort();
-        assert_eq!(values, vec!["bar", "boom"]);
-    }
 
     #[test]
     fn requests_convert() {

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,9 +2,10 @@
 
 // Std
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{hash_map::Keys, HashMap};
 use std::fmt;
 use std::mem;
+use std::sync::Arc;
 
 // Third Party
 use http::header::{HeaderValue, HOST};
@@ -29,15 +30,92 @@ pub struct GatewayRequest<'a> {
     #[serde(deserialize_with = "deserialize_headers")]
     pub(crate) headers: HeaderMap<HeaderValue>,
     #[serde(deserialize_with = "nullable_default")]
-    pub(crate) query_string_parameters: HashMap<String, String>,
+    pub(crate) query_string_parameters: StrMap,
     #[serde(deserialize_with = "nullable_default")]
-    pub(crate) path_parameters: HashMap<String, String>,
+    pub(crate) path_parameters: StrMap,
     #[serde(deserialize_with = "nullable_default")]
-    pub(crate) stage_variables: HashMap<String, String>,
+    pub(crate) stage_variables: StrMap,
     pub(crate) body: Option<Cow<'a, str>>,
     #[serde(default)]
     pub(crate) is_base64_encoded: bool,
     pub(crate) request_context: RequestContext,
+}
+
+/// A read-only view into a map of string data
+#[derive(Default, Debug, PartialEq)]
+pub struct StrMap(pub(crate) Arc<HashMap<String, String>>);
+
+impl StrMap {
+    /// Return a named value where available
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(|value| value.as_ref())
+    }
+
+    /// Return true if the underlying map is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Return an iterator over keys and values
+    pub fn iter(&self) -> StrMapIter {
+        StrMapIter(self, self.0.keys())
+    }
+}
+
+impl Clone for StrMap {
+    fn clone(&self) -> Self {
+        // only clone the inner data
+        StrMap(self.0.clone())
+    }
+}
+impl From<HashMap<String, String>> for StrMap {
+    fn from(inner: HashMap<String, String>) -> Self {
+        StrMap(Arc::new(inner))
+    }
+}
+
+/// A read only reference to `StrMap` key and value slice pairings
+pub struct StrMapIter<'a>(&'a StrMap, Keys<'a, String, String>);
+
+impl<'a> Iterator for StrMapIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    #[inline]
+    fn next(&mut self) -> Option<(&'a str, &'a str)> {
+        self.1
+            .next()
+            .and_then(|k| self.0.get(k).map(|v| (k.as_str(), v)))
+    }
+}
+
+impl<'de> Deserialize<'de> for StrMap {
+    fn deserialize<D>(deserializer: D) -> Result<StrMap, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StrMapVisitor;
+
+        impl<'de> Visitor<'de> for StrMapVisitor {
+            type Value = StrMap;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a StrMap")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut inner = HashMap::new();
+                while let Some((key, value)) = map.next_entry()? {
+                    inner.insert(key, value);
+                }
+                Ok(StrMap(Arc::new(inner)))
+            }
+        }
+
+        deserializer.deserialize_map(StrMapVisitor)
+    }
 }
 
 /// API Gateway request context
@@ -115,7 +193,7 @@ where
     T: Default + Deserialize<'de>,
 {
     let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or_else(Default::default))
+    Ok(opt.unwrap_or_else(T::default))
 }
 
 impl<'a> From<GatewayRequest<'a>> for HttpRequest<Body> {
@@ -177,6 +255,31 @@ mod tests {
     use super::*;
     use serde_json;
     use std::collections::HashMap;
+
+    #[test]
+    fn str_map_default_is_empty() {
+        assert!(StrMap::default().is_empty())
+    }
+
+    #[test]
+    fn str_map_get() {
+        let mut data = HashMap::new();
+        data.insert("foo".into(), "bar".into());
+        let strmap = StrMap(data.into());
+        assert_eq!(strmap.get("foo"), Some("bar"));
+        assert_eq!(strmap.get("bar"), None);
+    }
+
+    #[test]
+    fn str_map_iter() {
+        let mut data = HashMap::new();
+        data.insert("foo".into(), "bar".into());
+        data.insert("baz".into(), "boom".into());
+        let strmap = StrMap(data.into());
+        let mut values = strmap.iter().map(|(_, v)| v).collect::<Vec<_>>();
+        values.sort();
+        assert_eq!(values, vec!["bar", "boom"]);
+    }
 
     #[test]
     fn requests_convert() {

--- a/src/strmap.rs
+++ b/src/strmap.rs
@@ -21,7 +21,10 @@ impl StrMap {
 
     /// Return an iterator over keys and values
     pub fn iter(&self) -> StrMapIter {
-        StrMapIter(self, self.0.keys())
+        StrMapIter {
+            data: self,
+            keys: self.0.keys(),
+        }
     }
 }
 
@@ -38,16 +41,19 @@ impl From<HashMap<String, String>> for StrMap {
 }
 
 /// A read only reference to `StrMap` key and value slice pairings
-pub struct StrMapIter<'a>(&'a StrMap, Keys<'a, String, String>);
+pub struct StrMapIter<'a> {
+    data: &'a StrMap,
+    keys: Keys<'a, String, String>,
+}
 
 impl<'a> Iterator for StrMapIter<'a> {
     type Item = (&'a str, &'a str);
 
     #[inline]
     fn next(&mut self) -> Option<(&'a str, &'a str)> {
-        self.1
+        self.keys
             .next()
-            .and_then(|k| self.0.get(k).map(|v| (k.as_str(), v)))
+            .and_then(|k| self.data.get(k).map(|v| (k.as_str(), v)))
     }
 }
 

--- a/src/strmap.rs
+++ b/src/strmap.rs
@@ -1,0 +1,113 @@
+use std::collections::{hash_map::Keys, HashMap};
+use std::fmt;
+use std::sync::Arc;
+
+use serde::{de::MapAccess, de::Visitor, Deserialize, Deserializer};
+
+/// A read-only view into a map of string data
+#[derive(Default, Debug, PartialEq)]
+pub struct StrMap(pub(crate) Arc<HashMap<String, String>>);
+
+impl StrMap {
+    /// Return a named value where available
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(|value| value.as_ref())
+    }
+
+    /// Return true if the underlying map is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Return an iterator over keys and values
+    pub fn iter(&self) -> StrMapIter {
+        StrMapIter(self, self.0.keys())
+    }
+}
+
+impl Clone for StrMap {
+    fn clone(&self) -> Self {
+        // only clone the inner data
+        StrMap(self.0.clone())
+    }
+}
+impl From<HashMap<String, String>> for StrMap {
+    fn from(inner: HashMap<String, String>) -> Self {
+        StrMap(Arc::new(inner))
+    }
+}
+
+/// A read only reference to `StrMap` key and value slice pairings
+pub struct StrMapIter<'a>(&'a StrMap, Keys<'a, String, String>);
+
+impl<'a> Iterator for StrMapIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    #[inline]
+    fn next(&mut self) -> Option<(&'a str, &'a str)> {
+        self.1
+            .next()
+            .and_then(|k| self.0.get(k).map(|v| (k.as_str(), v)))
+    }
+}
+
+impl<'de> Deserialize<'de> for StrMap {
+    fn deserialize<D>(deserializer: D) -> Result<StrMap, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StrMapVisitor;
+
+        impl<'de> Visitor<'de> for StrMapVisitor {
+            type Value = StrMap;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a StrMap")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut inner = HashMap::new();
+                while let Some((key, value)) = map.next_entry()? {
+                    inner.insert(key, value);
+                }
+                Ok(StrMap(Arc::new(inner)))
+            }
+        }
+
+        deserializer.deserialize_map(StrMapVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn str_map_default_is_empty() {
+        assert!(StrMap::default().is_empty())
+    }
+
+    #[test]
+    fn str_map_get() {
+        let mut data = HashMap::new();
+        data.insert("foo".into(), "bar".into());
+        let strmap = StrMap(data.into());
+        assert_eq!(strmap.get("foo"), Some("bar"));
+        assert_eq!(strmap.get("bar"), None);
+    }
+
+    #[test]
+    fn str_map_iter() {
+        let mut data = HashMap::new();
+        data.insert("foo".into(), "bar".into());
+        data.insert("baz".into(), "boom".into());
+        let strmap = StrMap(data.into());
+        let mut values = strmap.iter().map(|(_, v)| v).collect::<Vec<_>>();
+        values.sort();
+        assert_eq!(values, vec!["bar", "boom"]);
+    }
+}


### PR DESCRIPTION
hashmap was very mvp. into addition to transfering ownership in ext methods it allowed for mutabililty which shouldn't be needed in the context of an incoming request. instead we substitute with a type with read only interfaces that clones via Arc pointer ( since request.extentions require Sync ). This should be cheaper. a minimal set of interfaces is provided `get(name)`, `is_empty()` and `iter()`